### PR TITLE
Fix for Reindexing issue and back-office UI to re-index

### DIFF
--- a/src/uLocate.UI/App_Plugins/uLocate/Backoffice/uLocate/locations.html
+++ b/src/uLocate.UI/App_Plugins/uLocate/Backoffice/uLocate/locations.html
@@ -17,6 +17,9 @@
                             <li class="action sep">
                                 <a ng-click="getLocations(); openMenu = !openMenu;"><i class="icon icon-refresh"></i><span class="menu-label"><localize key="actions_refreshNode">Reload nodes</localize></span></a>
                             </li>
+                            <li class="action">
+                                <a ng-click="reindexExamine(); openMenu = !openMenu;"><i class="icon icon-molecular"></i><span class="menu-label">Reindex</span></a>
+                            </li>
                         </ul>
                     </div>
                 </div>
@@ -27,6 +30,7 @@
 
             <div class="umb-pane">
                 <div class="well" style="background-color: #2e8aea; color: white;" ng-show="isGeocoding">Geocoding the coordinates for the address. This may take a moment. Do not leave or reload page or your location might not save properly.</div>
+                <div class="well" style="background-color: #2e8aea; color: white;" ng-show="isReindexing">Reindexing Examine from the Database. This may take a moment. Do not leave or reload page.</div>
                 <div class="map-wrapper span12">
                     <div class="map-bar top row-fluid">
                         <!-- Loading Notification -->

--- a/src/uLocate.UI/App_Plugins/uLocate/Scripts/Controllers/locations.controller.js
+++ b/src/uLocate.UI/App_Plugins/uLocate/Scripts/Controllers/locations.controller.js
@@ -1,6 +1,6 @@
 ﻿(function(controllers, undefined) {
 
-    controllers.LocationsController = function ($scope, $location, $q, $routeParams, treeService, assetsService, dialogService, navigationService, notificationsService, uLocateBroadcastService, uLocateDataTypeApiService, uLocateInitializationApiService, uLocateMapService, uLocateLocationApiService, uLocateLocationTypeApiService) {
+    controllers.LocationsController = function ($scope, $location, $q, $routeParams, treeService, assetsService, dialogService, navigationService, notificationsService, uLocateBroadcastService, uLocateDataTypeApiService, uLocateInitializationApiService, uLocateMapService, uLocateLocationApiService, uLocateLocationTypeApiService, uLocateManagementApiService) {
 
         /*-------------------------------------------------------------------
          * Initialization Methods
@@ -139,6 +139,7 @@
             $scope.filter = '';
             $scope.form = {};
             $scope.isGeocoding = false;
+            $scope.isReindexing = false;
             $scope.locations = [];
             $scope.locationsLoaded = false;
             $scope.locationTypes = uLocate.Constants.LOCATION_TYPES;
@@ -715,6 +716,31 @@
             });
         };
 
+
+        /**
+         * @ngdoc method
+         * @name reindexExamine
+         * @function
+         * 
+         * @description - Reindex the Examine index.
+         */
+        $scope.reindexExamine = function () {
+
+            $scope.openMenu = false;
+            notificationsService.success("Reindexing Examine locations.");
+            $scope.isReindexing = true;
+
+            uLocateManagementApiService.reindexExamine().then(function (response) {
+                if (response.Success) {
+                    notificationsService.success("Reindexing Examine locations complete.");
+                }
+                else {
+                    notificationsService.error("Attempt to reindex Examine failed.", response.Message);
+                }
+                $scope.isReindexing = false;
+            });
+        };
+
         /**
          * @ngdoc method
          * @name getLocationTypes
@@ -921,6 +947,6 @@
 
     };
 
-    angular.module('umbraco').controller('uLocate.Controllers.LocationsController', ['$scope', '$location', '$q', '$routeParams', 'treeService', 'assetsService', 'dialogService', 'navigationService', 'notificationsService', 'uLocateBroadcastService', 'uLocateDataTypeApiService', 'uLocateInitializationApiService', 'uLocateMapService', 'uLocateLocationApiService', 'uLocateLocationTypeApiService', uLocate.Controllers.LocationsController]);
+    angular.module('umbraco').controller('uLocate.Controllers.LocationsController', ['$scope', '$location', '$q', '$routeParams', 'treeService', 'assetsService', 'dialogService', 'navigationService', 'notificationsService', 'uLocateBroadcastService', 'uLocateDataTypeApiService', 'uLocateInitializationApiService', 'uLocateMapService', 'uLocateLocationApiService', 'uLocateLocationTypeApiService', 'uLocateManagementApiService', uLocate.Controllers.LocationsController]);
 
 }(window.uLocate.Controllers = window.uLocate.Controllers || {}));

--- a/src/uLocate.UI/App_Plugins/uLocate/Scripts/Services/management.api.service.js
+++ b/src/uLocate.UI/App_Plugins/uLocate/Scripts/Services/management.api.service.js
@@ -1,0 +1,28 @@
+﻿(function(uLocateServices) {
+
+	uLocateServices.ManagementApiService = function ($http) {
+
+	    var managementApiFactory = {};
+
+	    /**
+         * @ngdoc method
+         * @name reindexExamine
+         * @function
+         * 
+         * @returns {bool}
+         * @description - Reindex examine.
+         */
+	    managementApiFactory.reindexExamine = function () {
+	        return $http.get('/umbraco/backoffice/uLocate/MaintenanceApi/ReIndexAll/').then(function (response) {
+	            return response.data;
+	        });
+	    };
+
+
+	    return managementApiFactory;
+
+	};
+
+	angular.module('umbraco.resources').factory('uLocateManagementApiService', ['$http', uLocate.Services.ManagementApiService]);
+
+}(window.uLocate.Services = window.uLocate.Services || {}));

--- a/src/uLocate.UI/App_Plugins/uLocate/package.manifest
+++ b/src/uLocate.UI/App_Plugins/uLocate/package.manifest
@@ -14,6 +14,7 @@
         "~/App_Plugins/uLocate/Scripts/Services/file.api.service.js",
         "~/App_Plugins/uLocate/Scripts/Services/map.service.js",
         "~/App_Plugins/uLocate/Scripts/Services/localization.service.js",
+        "~/App_Plugins/uLocate/Scripts/Services/management.api.service.js",
         "~/App_Plugins/uLocate/Scripts/Directives/localize.js",
         "~/App_Plugins/uLocate/Scripts/Controllers/create.location.dialog.controller.js",
         "~/App_Plugins/uLocate/Scripts/Controllers/create.location.type.dialog.controller.js",

--- a/src/uLocate/Models/EditableLocation.cs
+++ b/src/uLocate/Models/EditableLocation.cs
@@ -141,7 +141,12 @@
         {
             get
             {
-                return this.PropertyData.FirstOrDefault(p => p.PropertyAlias == Constants.DefaultLocPropertyAlias.Phone).Value.ToString();
+                var locationPropertyData = this.PropertyData.FirstOrDefault(p => p.PropertyAlias == Constants.DefaultLocPropertyAlias.Phone);
+                if (locationPropertyData != null)
+                {
+                    return locationPropertyData.Value.ToString();
+                }
+                return "";
             }
 
             set
@@ -157,7 +162,12 @@
         {
             get
             {
-                return this.PropertyData.FirstOrDefault(p => p.PropertyAlias == Constants.DefaultLocPropertyAlias.Email).Value.ToString();
+                var locationPropertyData = this.PropertyData.FirstOrDefault(p => p.PropertyAlias == Constants.DefaultLocPropertyAlias.Email);
+                if (locationPropertyData != null)
+                {
+                    return locationPropertyData.Value.ToString();                    
+                }
+                return "";
             }
 
             set


### PR DESCRIPTION
Added null check during reindexing to prevent failure if location props were null.  

Added a way to reindex from the back-office via the "Actions" menu in the Locations in the uLocate custom section.
